### PR TITLE
Remove unnecessary resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@ name := "sbt-sassify"
 organization := "org.irundaia.sbt"
 sbtPlugin := true
 
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.2.2")
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
SBT include the Typesafe repo by default. Also, it's a security risk to include an http resolver - resolvers should always be https
