### PR TITLE
Cross build for SBT 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: scala
-scala:
-   - 2.10.6
-jdk:
-   - oraclejdk8
+
 sudo: false
+
 notifications: 
   email: false
+
+jdk:
+   - oraclejdk8
+
+env:
+  matrix:
+    - TRAVIS_SBT_VERSION=0.13.16
+    - TRAVIS_SBT_VERSION=1.0.0
+
 script:
-  sbt test scripted
+  sbt ^^$TRAVIS_SBT_VERSION test scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
 env:
   matrix:
     - TRAVIS_SBT_VERSION=0.13.16
-    - TRAVIS_SBT_VERSION=1.0.0
+    - TRAVIS_SBT_VERSION=1.0.1
 
 script:
   sbt ^^$TRAVIS_SBT_VERSION test scripted

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ organizationName := "Han van Venrooij"
 startYear := Some(2017)
 sbtPlugin := true
 
-fork in Test := true
+fork in Test := false
 
 javaOptions += "-Djna.nosys=true"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,19 @@
 import com.typesafe.sbt.GitVersioning
 import com.typesafe.sbt.SbtGit.git
-import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
-import de.heikoseeberger.sbtheader.license.Apache2_0
-import de.heikoseeberger.sbtheader.HeaderKey._
+
 import java.time.LocalDate
 
 lazy val sbtSassify = project
   .in(file("."))
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(GitVersioning)
-  .settings(ScriptedPlugin.scriptedSettings)
+  .enablePlugins(ScriptedPlugin)
   .settings(git.gitUncommittedChanges := false)
 
 name := "sbt-sassify"
 organization := "org.irundaia.sbt"
+organizationName := "Han van Venrooij"
+startYear := Some(2017)
 sbtPlugin := true
 
 fork in Test := true
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
 )
 
 // Compiler settings
-scalaVersion := "2.10.6"
+crossSbtVersions := Seq("1.0.1", "0.13.16")
 sourcesInBase := false
 crossPaths := false
 scalacOptions ++= Seq(
@@ -50,16 +50,11 @@ publishMavenStyle := false
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 publish := (publish dependsOn (test in Test)).value
 
-headers := Map(
-  "scala" -> Apache2_0(LocalDate.now().getYear.toString, "Han van Venrooij"),
-  "java" -> Apache2_0(LocalDate.now.getYear.toString, "Han van Venrooij")
-)
-
 // Scalastyle settings
 lazy val testScalastyle = taskKey[Unit]("testScalastyle")
-testScalastyle := org.scalastyle.sbt.ScalastylePlugin.scalastyle.in(Compile).toTask("").value
-org.scalastyle.sbt.ScalastylePlugin.scalastyleFailOnError := true
+testScalastyle := scalastyle.in(Compile).toTask("").value
+scalastyleFailOnError := true
 
 // Scripted settings
-ScriptedPlugin.scriptedBufferLog := false
-ScriptedPlugin.scriptedLaunchOpts += "-Dplugin.version=" + version.value
+scriptedBufferLog := false
+scriptedLaunchOpts += "-Dplugin.version=" + version.value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.1")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-//addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.14")
+addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,15 @@
 // Project plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
 // Testing plugins
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 // Style and code style plugins
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "3.0.1")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.14")
+//addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.14")

--- a/src/main/scala/org/irundaia/sass/Options.scala
+++ b/src/main/scala/org/irundaia/sass/Options.scala
@@ -21,8 +21,6 @@ import java.nio.file.{Path, Paths}
 
 import org.irundaia.sass.jna.SassLibrary
 
-import scala.language.implicitConversions
-
 case class Options(nativeOptions: SassLibrary.Sass_Options) {
   def precision: Int = SassLibrary.INSTANCE.sass_option_get_precision(this.nativeOptions)
   def precision_=(precision: Int): Unit = SassLibrary.INSTANCE.sass_option_set_precision(this.nativeOptions, precision)

--- a/src/sbt-test/imports/in-webjar/build.sbt
+++ b/src/sbt-test/imports/in-webjar/build.sbt
@@ -2,5 +2,5 @@ lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
 libraryDependencies ++= Seq(
   "org.webjars.bower" % "bootstrap-sass" % "3.3.6",
-  "org.webjars" %% "webjars-play" % "2.4.0-1"
+  "org.webjars" %% "webjars-play" % "2.6.2"
 )

--- a/src/sbt-test/imports/in-webjar/build.sbt
+++ b/src/sbt-test/imports/in-webjar/build.sbt
@@ -1,6 +1,15 @@
 lazy val root = (project in file(".")).enablePlugins(SbtWeb)
 
+lazy val playVersion = settingKey[String]("Play version in relation to current Scala Version")
+
+playVersion := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 10)) => "2.4.0-2"
+    case Some((2, n)) if n > 10 => "2.6.2"
+  }
+}
+
 libraryDependencies ++= Seq(
   "org.webjars.bower" % "bootstrap-sass" % "3.3.6",
-  "org.webjars" %% "webjars-play" % "2.6.2"
+  "org.webjars" %% "webjars-play" % playVersion.value
 )

--- a/src/test/scala/org/irundaia/sass/SassCompilerTest.scala
+++ b/src/test/scala/org/irundaia/sass/SassCompilerTest.scala
@@ -21,7 +21,6 @@ import java.nio.file.{Paths, Files}
 import org.scalatest.{FunSpec, MustMatchers}
 
 import scala.io.Source
-import scala.util.Failure
 
 class SassCompilerTest extends FunSpec with MustMatchers {
   val testDir = Files.createTempDirectory("sbt-sassify")


### PR DESCRIPTION
Updated the base build of the plugin to use SBT 1.x while still cross-building for SBT 0.13. This required updating a few build plugins.

Some minor changes in the code have been needed due to the stronger rules in the Scala 2.12 compiler-linter.

Addresses #25 